### PR TITLE
allow inline build with obs-studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,8 @@ include_directories(
 	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api"
 	${Qt5Core_INCLUDES}
 	${Qt5Widgets_INCLUDES}
-	"${CMAKE_SOURCE_DIR}/deps/asio/asio/include"
-	"${CMAKE_SOURCE_DIR}/deps/websocketpp")
+	"${CMAKE_CURRENT_SOURCE_DIR}/deps/asio/asio/include"
+	"${CMAKE_CURRENT_SOURCE_DIR}/deps/websocketpp")
 
 target_link_libraries(obs-websocket
 	libobs


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md -->

### Description
when replacing CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR in the CMakeLists.txt this should allow for building the plugin directly inside of obs-studio as well as separately

### Motivation and Context
I'm in the process of building an automated pipeline with all the plugins I use (and then some) directly with the latest git version of OBS. The easiest way for me to do this is, if I can build all those plugins directly inside of the obs-studio/plugins/ directory right when I build OBS itself.
This change will allow me exactly that, while still being compatible with Palakis' workflow to build it individually.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
this has been tested on the docker image ubuntu:groovy in my pipeline at https://gitlab.argonet.de/argonet/build-obs/-/pipelines

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Enhancement (modification to a current event/request which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [ ] All commit messages are properly formatted and commits squashed where appropriate.
-   [ ] I have included updates to all appropriate documentation.

